### PR TITLE
fix: default bg color

### DIFF
--- a/components/socialcard.js
+++ b/components/socialcard.js
@@ -27,7 +27,7 @@ export default function LinkCard({
       ...item,
       bgColor: {
         transparent: item.bgColor === "transparent" ? "true" : false,
-        color: item.bgColor === "transparent" ? "#000" : item.bgColor,
+        color: item.bgColor === "transparent" ? "#2c6bed" : item.bgColor,
       },
     },
   });
@@ -197,6 +197,7 @@ export default function LinkCard({
                           Link background color
                         </label>
                         <input
+                          defaultValue="#2c6bed"
                           type="color"
                           className="form-control form-control-sm mb-2 form-control-color"
                           title="Choose Link background color"


### PR DESCRIPTION
### Guidelines

- [x] I read the [Contributing Guidelines](https://github.com/CONTRIBUTING.md) 

### This pull request regarding on

- [x] fixed a bug

### Briefly describe what you did

Fixed a bug with default background social icons value

With bug: default bg changes when auto save and no color selected

![2021-12-12 17-52-45](https://user-images.githubusercontent.com/77246331/145721960-401436fc-c461-42d4-9a62-352ace11c4df.gif)

Bug fixed: bg color doesnt change

![2021-12-12 18-00-00](https://user-images.githubusercontent.com/77246331/145722033-48ff03f8-d83b-4703-9a0b-b7339ee397d3.gif)




## Appreciate your contribution to making Linkin better 🚀.
